### PR TITLE
Cvat compatibility and bug fixes

### DIFF
--- a/pylabel/analyze.py
+++ b/pylabel/analyze.py
@@ -11,7 +11,7 @@ class Analyze:
     @property 
     def classes(self):
         cat_names = list(self.dataset.df.cat_name.unique())
-        return [i for i in cat_names if i.strip() != '']
+        return [i for i in cat_names if str(i).strip() != '']
 
     @property 
     def class_counts(self):
@@ -20,7 +20,7 @@ class Analyze:
     @property 
     def num_classes(self):
         cat_names = list(self.dataset.df.cat_name.unique())
-        return len([i for i in cat_names if i.strip() != ''])
+        return len([i for i in cat_names if str(i).strip() != ''])
         
     @property 
     def num_images(self):

--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -206,7 +206,7 @@ class Export():
 
         return output_file_paths
 
-    def ExportToYoloV5(self, output_path=None, yaml_file=None, copy_images=False, use_splits=False):
+    def ExportToYoloV5(self, output_path='training/labels', yaml_file='dataset.yaml', copy_images=False, use_splits=False):
         """ Writes annotation files to disk and returns path to files.
         
         Args:
@@ -295,7 +295,7 @@ class Export():
                 if use_splits:
                     split_dir = df_single_img_annots.iloc[0].split
                 else:
-                    split_dir = split_dir
+                    split_dir = '' 
                 destination = str(PurePath(dest_folder, split_dir, annot_txt_file))
                 Path(dest_folder, split_dir,).mkdir(parents=True, exist_ok=True) 
 

--- a/pylabel/importer.py
+++ b/pylabel/importer.py
@@ -35,8 +35,20 @@ def ImportCoco(path, path_to_images=None, name=""):
     #Store the 3 sections of the json as seperate json arrays
     images = pd.json_normalize(annotations_json["images"])
     images.columns = 'img_' + images.columns
+    try:
+        images["img_folder"]
+    except:
+        images["img_folder"] = ""
+    #print(images)
     images["img_folder"] = _GetValueOrBlank(images["img_folder"], path_to_images)
-    images = images.astype({'img_width': 'int64','img_height': 'int64','img_depth': 'int64'})
+    astype_dict = {'img_width': 'int64','img_height': 'int64','img_depth': 'int64'}
+    astype_keys = list(astype_dict.keys())
+    for element in astype_keys:
+        if element not in images.columns:
+            astype_dict.pop(element)
+    #print(astype_dict)
+    #images = images.astype({'img_width': 'int64','img_height': 'int64','img_depth': 'int64'})
+    images = images.astype(astype_dict)
 
     annotations = pd.json_normalize(annotations_json["annotations"])
     annotations.columns = 'ann_' + annotations.columns


### PR DESCRIPTION
### CVAT Compatibility and over bug fixes

I tried using this package to convert my coco annotations of a custom data-set, which was annotated in CVAT, to YOLOV5 labels. I ran into some issues and have fixed them and hope they may be of use to others as well.

The issues are also explained in the commit messages.

1. importer.py: the tag "img_folder" was required to be in coco annotations but this is not a necessary tag, it is often left blank or not included at all, when it is not included a KeyError occured. There was an attempt at this in place with a call _GetValueOrBlank(images["img_folder"], path_to_images) which though still requires there to be an "img_folder" in images even if an alternative path was given by the user.
Fixed by checking if this tag/column exists and creating it empty if it does not yet exist

2. Same issue as 1. only with img_depth, it is not required in the coco annotation format and is not given when exporting from cvat

3. exporter.py, ExportToYoloV5():
 -default value of yaml_file=None leads to TypeError: expected str, ... fixed by setting default value to the recommended yaml_file='dataset.yaml'
 -fix to the issue that not using splits created "UnboundLocalError: local variable 'split_dir' referenced before assignment"
fixed by setting split_dir = '' if no split is wanted

4. analize.py
bug: i in cat_names was assumed to be str and caused error "AttributeError: 'float' object has no attribute 'strip'"
fix: typecast str(i) before calling strip

Please let me know if there is anything you need me to change and thank you for creating this package. 