### PR TITLE
fix "Max Recursion Level Reached" issue

### DIFF
--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -693,9 +693,9 @@ class Export:
         mergedA = pd.concat(df_outputA, ignore_index=True)
         mergedC = pd.concat(df_outputC, ignore_index=True)
 
-        resultI = mergedI[0].to_json(orient="split")
-        resultA = mergedA[0].to_json(orient="split")
-        resultC = mergedC[0].to_json(orient="split")
+        resultI = mergedI[0].to_json(orient="split", default_handler=str)
+        resultA = mergedA[0].to_json(orient="split", default_handler=str)
+        resultC = mergedC[0].to_json(orient="split", default_handler=str)
 
         parsedI = json.loads(resultI)
         del parsedI["index"]


### PR DESCRIPTION
This forces the json formatter to use a string representation for any unwanted type. I tested it with monkey patching but i am not sure if you use other test to verify the code changes. If you would like I can recreate the issues in a colab notebook. 
https://stackoverflow.com/questions/60490169/maximum-recursion-level-reached-converting-pandas-dataframe-to-json#60490274.