### PR TITLE
Add support for multiple image extension for YOLOv5 dataset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="pylabel",
     packages=["pylabel"],
-    version="0.1.31",
+    version="0.1.32",
     description="Transform, analyze, and visualize computer vision annotations.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This wil resolve issue #26 . The img_ext variable can now accept a list of file formats such as "jpg,jpeg,png". 
