### PR TITLE
Cast `category_id` field value from `str` to `int` 

### DIFF
--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -678,29 +678,30 @@ class Export:
                 }
             ]
 
-            annotations = [
-                {
-                    "image_id": df["img_id"][i],
-                    "id": df.index[i],
-                    "segmented": df["ann_segmented"][i],
-                    "bbox": [
-                        df["ann_bbox_xmin"][i],
-                        df["ann_bbox_ymin"][i],
-                        df["ann_bbox_width"][i],
-                        df["ann_bbox_height"][i],
-                    ],
-                    "area": df["ann_area"][i],
-                    "segmentation": df["ann_segmentation"][i],
-                    "iscrowd": df["ann_iscrowd"][i],
-                    "pose": df["ann_pose"][i],
-                    "truncated": df["ann_truncated"][i],
-                    "category_id": int(df["cat_id"][i]),
-                    "difficult": df["ann_difficult"][i],
-                }
-            ]
-
             # Skip this if cat_id is na
             if not pd.isna(df["cat_id"][i]):
+
+                annotations = [
+                    {
+                        "image_id": df["img_id"][i],
+                        "id": df.index[i],
+                        "segmented": df["ann_segmented"][i],
+                        "bbox": [
+                            df["ann_bbox_xmin"][i],
+                            df["ann_bbox_ymin"][i],
+                            df["ann_bbox_width"][i],
+                            df["ann_bbox_height"][i],
+                        ],
+                        "area": df["ann_area"][i],
+                        "segmentation": df["ann_segmentation"][i],
+                        "iscrowd": df["ann_iscrowd"][i],
+                        "pose": df["ann_pose"][i],
+                        "truncated": df["ann_truncated"][i],
+                        "category_id": int(df["cat_id"][i]),
+                        "difficult": df["ann_difficult"][i],
+                    }
+                ]
+
                 categories = [
                     {
                         "id": int(df["cat_id"][i]),

--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -694,7 +694,7 @@ class Export:
                     "iscrowd": df["ann_iscrowd"][i],
                     "pose": df["ann_pose"][i],
                     "truncated": df["ann_truncated"][i],
-                    "category_id": df["cat_id"][i],
+                    "category_id": int(df["cat_id"][i]),
                     "difficult": df["ann_difficult"][i],
                 }
             ]


### PR DESCRIPTION
This PR casts the `category_id` field value from `str` to `int` data type to be consistent with the COCO data format.

I have also checked the other fields and found everything is consistent with the format outlined in https://cocodataset.org/#format-data

Closes #46
