### PR TITLE
modify tqdm use

### DIFF
--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -381,8 +381,8 @@ class Export:
                 return output_file_path
 
         # Loop through all images in the dataframe and call voc_xml_file_creation for each one
-        for file_title in tqdm(list(set(self.dataset.df.img_filename)), desc='Exporting files'):
-
+        pbar = tqdm(desc="Exporting VOC files...", total=len(list(set(self.dataset.df.img_filename))))
+        for file_title in list(set(self.dataset.df.img_filename)):
             file_name = Path(file_title)
             file_name = str(file_name.with_suffix(".xml"))
             file_path = str(Path(output_path, file_name))
@@ -397,6 +397,7 @@ class Export:
                 output_file_path=file_path,
             )
             output_file_paths.append(voc_file_path)
+            pbar.update()
 
         return output_file_paths
 
@@ -538,8 +539,8 @@ class Export:
 
         unique_images = yolo_dataset["img_filename"].unique()
         output_file_paths = []
-
-        for img_filename in tqdm(unique_images, desc='Exporting files'):
+        pbar = tqdm(desc="Exporting YOLO files...", total=len(unique_images))
+        for img_filename in unique_images:
             df_single_img_annots = yolo_dataset.loc[
                 yolo_dataset.img_filename == img_filename
             ]
@@ -631,6 +632,7 @@ class Export:
                     str(source_image_path),
                     str(PurePath(path_dict["image_path"], split_dir, img_filename)),
                 )
+            pbar.update()
 
         # Create YAML file
         if yaml_file:
@@ -708,7 +710,8 @@ class Export:
         list_c = []
         json_list = []
 
-        for i in tqdm(range(0, df.shape[0]), desc="Exporting files"):
+        pbar = tqdm(desc="Exporting to COCO file...", total=range(0, df.shape[0]))
+        for i in range(0, df.shape[0]):
             images = [
                 {
                     "id": df["img_id"][i],
@@ -781,6 +784,8 @@ class Export:
             # If the class id is blank, then there is no annotation to add
             if not pd.isna(categories[0]["id"]):
                 df_outputA.append(pd.DataFrame([annotations]))
+
+            pbar.update()
 
         mergedI = pd.concat(df_outputI, ignore_index=True)
         mergedA = pd.concat(df_outputA, ignore_index=True)

--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -710,7 +710,7 @@ class Export:
         list_c = []
         json_list = []
 
-        pbar = tqdm(desc="Exporting to COCO file...", total=range(0, df.shape[0]))
+        pbar = tqdm(desc="Exporting to COCO file...", total=df.shape[0])
         for i in range(0, df.shape[0]):
             images = [
                 {

--- a/pylabel/importer.py
+++ b/pylabel/importer.py
@@ -182,6 +182,7 @@ def ImportVOC(path, path_to_images=None, name="dataset", encoding='utf-8'):
         return cat_names.index(cat_name)
 
     # iterate over files in that directory
+    pbar = tqdm(desc="Importing VOC files...", total=len(os.listdir(path)))
     for filename in os.scandir(path):
         if filename.is_file() and filename.name.endswith(".xml"):
             filepath = filename.path
@@ -229,6 +230,7 @@ def ImportVOC(path, path_to_images=None, name="dataset", encoding='utf-8'):
 
         # Increment the imageid because we are going to read annother file
         img_id += 1
+        pbar.update()
 
     # Convert the dict with all of the annotation data to a dataframe
     df = pd.DataFrame.from_dict(d, "index", columns=schema)
@@ -305,7 +307,8 @@ def ImportYoloV5(
     img_id = 0
 
     # iterate over files in that directory
-    for filename in tqdm(os.scandir(path), desc='Importing files'):
+    pbar = tqdm(desc="Importing YOLO files...", total=len(os.listdir(path)))
+    for filename in os.scandir(path):
         if filename.is_file() and filename.name.endswith(".txt"):
             filepath = filename.path
             file = open(filepath, "r", encoding=encoding)  # Read file
@@ -394,6 +397,7 @@ def ImportYoloV5(
                 # Add this row to the dict
         # increment the image id
         img_id += 1
+        pbar.update()
 
     df = pd.DataFrame.from_dict(d, "index", columns=schema)
     df.index.name = "id"
@@ -442,6 +446,8 @@ def ImportImagesOnly(path, name="dataset"):
     img_id = 0
 
     # iterate over files in that directory
+    pbar = tqdm(desc="Importing images files...", total=len(os.listdir(path)))
+
     for filename in os.scandir(path):
         if filename.is_file() and filename.name.lower().endswith(
             (".png", ".jpg", ".jpeg", ".tiff", ".bmp", ".gif")
@@ -471,6 +477,7 @@ def ImportImagesOnly(path, name="dataset"):
             # Add this row to the dict
             d[img_id] = row
             img_id += 1
+        pbar.update()
 
     df = pd.DataFrame.from_dict(d, "index", columns=schema)
     df.index.name = "id"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="pylabel",
     packages=["pylabel"],
-    version="0.1.46",
+    version="0.1.47",
     description="Transform, analyze, and visualize computer vision annotations.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
slight variation to the use of tqdm already added from #85 . Included in all importers/exports and with a defined length for progress/time remaining estimation.

Progress bar style can be updated as per some of [the examples here](https://github.com/tqdm/tqdm) by changing `pbar = tqdm(desc="", total=length_of_files, ascii=' =')`. Colour etc. can also be changed, but maybe not so critical!