### PR TITLE
Add capability to convert keypoints from COCO to YOLOv5 format

### DIFF
--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -816,6 +816,12 @@ class Export:
                     }
                 ]
 
+                # include keypoints, if available
+                if "ann_keypoints" in df.keys():
+                    n_keypoints = int(len(df["ann_keypoints"][i]) / 3)  # 3 numbers per keypoint: x,y,visibility
+                    annotations[0]["num_keypoints"] = n_keypoints
+                    annotations[0]["keypoints"] = df["ann_keypoints"][i]
+
                 categories = [
                     {
                         "id": int(df["cat_id"][i]),

--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -817,10 +817,18 @@ class Export:
                 ]
 
                 # include keypoints, if available
-                if "ann_keypoints" in df.keys():
-                    n_keypoints = int(len(df["ann_keypoints"][i]) / 3)  # 3 numbers per keypoint: x,y,visibility
+                if "ann_keypoints" in df.keys() and (not np.isnan(df["ann_keypoints"][i]).all()):
+                    keypoints = df["ann_keypoints"][i]
+                    if isinstance(keypoints, list):
+                        n_keypoints = int(len(keypoints) / 3)  # 3 numbers per keypoint: x,y,visibility
+                    elif isinstance(keypoints, np.ndarray):
+                        n_keypoints = int(keypoints.size / 3)  # 3 numbers per keypoint: x,y,visibility
+                    else:
+                        raise TypeError('The keypoints array is expected to be either a list or a numpy array')
                     annotations[0]["num_keypoints"] = n_keypoints
-                    annotations[0]["keypoints"] = df["ann_keypoints"][i]
+                    annotations[0]["keypoints"] = keypoints
+                else:
+                    pass
 
                 categories = [
                     {

--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -446,6 +446,7 @@ class Export:
         use_splits=False,
         cat_id_index=None,
         segmentation=False,
+        keypoints=False,
     ):
         """Writes annotation files to disk in YOLOv5 format and returns the paths to files.
 
@@ -470,13 +471,22 @@ class Export:
                 /train. If a YAML file is specificied then the YAML file will use the splits to specify the folders user for the
                 train, val, and test datasets.
             cat_id_index (int):
-                Reindex the cat_id values so that that they start from an int (usually 0 or 1) and
+                Reindex the cat_id values so that they start from an int (usually 0 or 1) and
                 then increment the cat_ids to index + number of categories continuously.
                 It's useful if the cat_ids are not continuous in the original dataset.
                 Yolo requires the set of annotations to start at 0 when training a model.
             segmentation (boolean):
                 If true, then segmentation annotations will be exported instead of bounding box annotations.
                 If there are no segmentation annotations, then no annotations will be empty.
+            keypoints (boolean):
+                If true, then keypoint annotations will be exported as well as bounding box annotations.
+                It is not possible to export both segmentation and keypoint annotations at the same time in YOLO format.
+                Each bounding box within a dataset should have the same number of keypoints defined e.g. 17 for COCO.
+                Keypoints are a triplet of (x, y, visibility), see e.g. https://cocodataset.org/#format-data
+                If some images have no keypoint annotations, then the bounding boxes will be followed by a series of
+                delimiting spaces.
+                If some bounding boxes within an image have no keypoint annotations, those keypoints will be a series of
+                zeroes, denoting x=0, y=0, visibility=0.
 
         Returns:
             A list with 1 or more paths (strings) to annotations files. If a YAML file is created
@@ -489,6 +499,8 @@ class Export:
 
         """
         ds = self.dataset
+
+        assert not (segmentation and keypoints), "Only one of segmentation and keypoints can be exported in YOLO format"
 
         # Inspired by https://github.com/aws-samples/groundtruth-object-detection/blob/master/create_annot.py
         yolo_dataset = ds.df.copy(deep=True)
@@ -563,24 +575,24 @@ class Export:
                 yolo_dataset["ann_bbox_height"] / yolo_dataset["img_height"]
             )
 
-            keypoints_yolo = [[] for _ in range(len(yolo_dataset.index))]
-            for img_ix, row in yolo_dataset.iterrows():
-                img_width = row["img_width"]
-                img_height = row["img_height"]
-                keypoints_coco = row["ann_keypoints"]
-                if keypoints_coco:
-                    for bbox_ix, kp in enumerate(keypoints_coco):
-                        if bbox_ix % 3 == 0:
-                            # x coordinate
-                            keypoints_yolo[img_ix].append(kp / img_width)
-                        elif bbox_ix % 3 == 1:
-                            # y coordinate
-                            keypoints_yolo[img_ix].append(kp / img_height)
-                        else:
-                            # visibility
-                            keypoints_yolo[img_ix].append(kp)
-            yolo_dataset["keypoints_scaled_as_string"] = keypoints_yolo
-
+            if keypoints:
+                keypoints_yolo = [[] for _ in range(len(yolo_dataset.index))]
+                for img_ix, row in yolo_dataset.iterrows():
+                    img_width = row["img_width"]
+                    img_height = row["img_height"]
+                    keypoints_coco = row["ann_keypoints"]
+                    if keypoints_coco:
+                        for bbox_ix, kp in enumerate(keypoints_coco):
+                            if bbox_ix % 3 == 0:
+                                # x coordinate
+                                keypoints_yolo[img_ix].append(kp / img_width)
+                            elif bbox_ix % 3 == 1:
+                                # y coordinate
+                                keypoints_yolo[img_ix].append(kp / img_height)
+                            else:
+                                # visibility
+                                keypoints_yolo[img_ix].append(kp)
+                yolo_dataset["keypoints_scaled"] = keypoints_yolo
 
         # Create folders to store annotations
         if output_path == None:
@@ -622,8 +634,9 @@ class Export:
                     "center_y_scaled",
                     "width_scaled",
                     "height_scaled",
-                    "keypoints_scaled_as_string"
                 ]
+                if keypoints:
+                    columns.append("keypoints_scaled")
 
                 self._df_to_csv(
                     df=df_single_img_annots,
@@ -734,7 +747,7 @@ class Export:
                 This is where the annotation files will be written. If not-specified then the path will be derived from the path_to_annotations and
                 name properties of the dataset object.
             cat_id_index (int):
-                Reindex the cat_id values so that that they start from an int (usually 0 or 1) and
+                Reindex the cat_id values so that they start from an int (usually 0 or 1) and
                 then increment the cat_ids to index + number of categories continuously.
                 It's useful if the cat_ids are not continuous in the original dataset.
                 Some models like Yolo require starting from 0 and others like Detectron require starting from 1.

--- a/pylabel/shared.py
+++ b/pylabel/shared.py
@@ -24,6 +24,7 @@ schema = [
     "ann_area",
     "ann_segmentation",
     "ann_iscrowd",
+    "ann_keypoints",
     "ann_pose",
     "ann_truncated",
     "ann_difficult",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="pylabel",
     packages=["pylabel"],
-    version="0.1.51",
+    version="0.1.52",
     description="Transform, analyze, and visualize computer vision annotations.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
In case you're interested in converting keypoints as well as bounding boxes.

Following the format from here:
https://github.com/WongKinYiu/yolov7/issues/1267

I did some manual tests on images with:

- no annotations (outputs a text file with only spaces)
- bounding box annotations but no keypoint annotations (outputs a text file with 5 fields per line, as usual)
- combinations of visible and not-visible keypoints (outputs the usual 5 fields per line, followed by Nx3 values for keypoints)