### PR TITLE
Fix importing VOC dataset with incorrect filename properties. Fix copying images after export.

### DIFF
--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -628,7 +628,6 @@ class Export:
                 Path(path_dict["image_path"], split_dir).mkdir(
                     parents=True, exist_ok=True
                 )
-                print(str(source_image_path))
                 shutil.copy(
                     str(source_image_path),
                     str(PurePath(path_dict["image_path"], split_dir, img_filename)),

--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -615,7 +615,7 @@ class Export:
             if copy_images:
                 source_image_path = str(
                     Path(
-                        ds.path_to_annotations,
+                        #ds.path_to_annotations,
                         df_single_img_annots.iloc[0].img_folder,
                         df_single_img_annots.iloc[0].img_filename,
                     )
@@ -628,6 +628,7 @@ class Export:
                 Path(path_dict["image_path"], split_dir).mkdir(
                     parents=True, exist_ok=True
                 )
+                print(str(source_image_path))
                 shutil.copy(
                     str(source_image_path),
                     str(PurePath(path_dict["image_path"], split_dir, img_filename)),

--- a/pylabel/importer.py
+++ b/pylabel/importer.py
@@ -189,7 +189,14 @@ def ImportVOC(path, path_to_images=None, name="dataset", encoding='utf-8'):
             xml_data = open(filepath, "r", encoding=encoding).read()  # Read file
             root = ET.XML(xml_data)  # Parse XML
             folder = _GetValueOrBlank(root.find("folder"), user_input=path_to_images)
-            filename = root.find("filename").text
+            
+            if path_to_images != None:
+                # find file that has same name without extension in the images folder
+                filename = next(
+                    (f for f in os.listdir(path_to_images) if f.startswith(filename.name[:-4])), None
+                )
+            else:
+                filename = root.find("filename").text
             size = root.find("size")
             size_width = size.find("width").text
             size_height = size.find("height").text
@@ -199,7 +206,7 @@ def ImportVOC(path, path_to_images=None, name="dataset", encoding='utf-8'):
             row = {}
             # Build dictionary that will be become the row in the dataframe
             row["img_folder"] = folder
-            row["img_filename"] = filename
+            row["img_filename"] = filename #filename.name
             row["img_id"] = img_id
             row["img_width"] = size_width
             row["img_height"] = size_height

--- a/pylabel/importer.py
+++ b/pylabel/importer.py
@@ -206,7 +206,7 @@ def ImportVOC(path, path_to_images=None, name="dataset", encoding='utf-8'):
             row = {}
             # Build dictionary that will be become the row in the dataframe
             row["img_folder"] = folder
-            row["img_filename"] = filename #filename.name
+            row["img_filename"] = filename 
             row["img_id"] = img_id
             row["img_width"] = size_width
             row["img_height"] = size_height


### PR DESCRIPTION
Greetings, 
When working with this package, I had two issues in importing a VOC dataset and exporting it to YoloV5 with images.

When importing a VOC dataset in pylabel, the filename property of each .xml annotation file is used to determine the name of the image name. That name is then used when exporting the dataset to other formats.   
In case the name is incorrect or is empty, this process fails and when exporting we do not get the correct number of annotations back. For example, if all .xml files had the same 'filename' property, we only get one file after export.

I fixed it by looking through the images directory and looking for an image with the same name as the annotations file.

Another issue this fixes in exporter.py is when copying images if exporting to YoloV5. In the code, the annotation path is merged with the images path, which generates an incorrect path for the images. I fixed it by commenting the annotation path in the Path concatenation code.

I hope my changes will not break any functionality. Please let me know if there is a better way to solve my issue.

Thank you for making this package public.
Kind regards,
Yaser.