### PR TITLE
Fix #143

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ BCCD_Dataset/
 model_training/
 __pycache__
 samples
+build/

--- a/pylabel/analyze.py
+++ b/pylabel/analyze.py
@@ -135,7 +135,7 @@ class Analyze:
             df.insert(pos, col.name, col)
 
         df_value_counts = pd.DataFrame(
-            ds.df["cat_name"].value_counts(normalize=normalize), columns=["cat_name"]
+            ds.df["cat_name"].value_counts(normalize=normalize)
         )
 
         df_value_counts.index.name = "cat_name"
@@ -150,12 +150,13 @@ class Analyze:
             group_df = pd.DataFrame(group)
             df_split_value_counts = pd.DataFrame(
                 group_df["cat_name"].value_counts(normalize=normalize),
-                columns=["cat_name"],
             )
             df_split_value_counts.index.name = "cat_name"
             df_split_value_counts.columns = [name]
             df_value_counts = pd.merge(
-                df_value_counts, df_split_value_counts, how="left", on=["cat_name"]
+                df_value_counts, df_split_value_counts, 
+                how="left", 
+                left_index=True, right_index=True
             )
 
         # Move 'train' to the left of the table since that is the usual convention.

--- a/pylabel/importer.py
+++ b/pylabel/importer.py
@@ -300,6 +300,8 @@ def ImportYoloV5(
 
     def GetCatNameFromId(cat_id, cat_names):
         cat_id = int(cat_id)
+        if not cat_names:
+            return str(cat_id)
         if len(cat_names) > int(cat_id):
             return cat_names[cat_id]
 


### PR DESCRIPTION
Fixes #143 

In case cat_name isn't provided, cat_id will be converted to string and used as cat_name. If this gets merged, this behavior should probably be documented though. 

Next, specifying "columns=["cat_name"]" when creating dataframe from value_counts returns empty dataframe because "cat_name" became the index in value_counts. Since it's an index, the merge will have to use index too.

I'm not sure if this is a changed behavior. I'm using pandas 2.1.3