### PR TITLE
fix some bug

### DIFF
--- a/pylabel/exporter.py
+++ b/pylabel/exporter.py
@@ -781,7 +781,7 @@ class Export:
         json_list = []
 
         pbar = tqdm(desc="Exporting to COCO file...", total=df.shape[0])
-        for i in range(0, df.shape[0]):
+        for i in df.index:
             images = [
                 {
                     "id": df["img_id"][i],
@@ -799,7 +799,7 @@ class Export:
                 annotations = [
                     {
                         "image_id": df["img_id"][i],
-                        "id": df.index[i],
+                        "id": i,
                         "segmented": df["ann_segmented"][i],
                         "bbox": [
                             df["ann_bbox_xmin"][i],


### PR DESCRIPTION
the code before asume the index of dataframe is continous, which is not after data get filted like code below, and when accessing the index doesn't exist, the code crash. I think this can fix it.
(: sorry for my poor english
```python
valid_data = []
error_data = []

for i in range(0, data.df.shape[0]):
    row = data.df.iloc[i]

    kps = row["ann_keypoints"]
    cnt = 0
    for j in range(0, len(kps), 3):
        if kps[j] == 0 and kps[j + 1] == 0 and kps[j + 2] == 0:
            cnt += 1

    if cnt > OUTSIDE_KPTS_THRESH:
        error_data.append(row)
        print(kps)

    else:
        valid_data.append(row)


data_out = dataset.Dataset(pd.DataFrame(valid_data).reindex())

data_out.export.ExportToCoco(coco_output_json)
```


```
Exporting to COCO file...:   0%|                                      | 0/12290 [00:00<?, ?it/s]Traceback (most recent call last):
  File "/data/zxw/anaconda3/envs/yolov8/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3629, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 136, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 163, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 2131, in pandas._libs.hashtable.Int64HashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 2140, in pandas._libs.hashtable.Int64HashTable.get_item
KeyError: 64

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/zxw/workspace/robomaster_ws/data/train_ws/coco_data_clean.py", line 44, in <module>
    data_out.export.ExportToCoco(coco_output_json)
  File "/data/zxw/anaconda3/envs/yolov8/lib/python3.8/site-packages/pylabel/exporter.py", line 787, in ExportToCoco
    "id": df["img_id"][i],
  File "/data/zxw/anaconda3/envs/yolov8/lib/python3.8/site-packages/pandas/core/series.py", line 958, in __getitem__
    return self._get_value(key)
  File "/data/zxw/anaconda3/envs/yolov8/lib/python3.8/site-packages/pandas/core/series.py", line 1069, in _get_value
    loc = self.index.get_loc(label)
  File "/data/zxw/anaconda3/envs/yolov8/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3631, in get_loc
    raise KeyError(key) from err
KeyError: 64
Exporting to COCO file...:   1%|▏                           | 64/12290 [00:00<00:17, 710.37it/s]
```